### PR TITLE
add plugin-loader-observability patch: make plugin load failures visible

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -102,6 +102,17 @@ jobs:
             test/cli/tui/reconcile-bound.test.tsx \
             test/cli/cmd/tui/bootstrap-settled.test.tsx
 
+      # plugin-loader-observability.patch makes plugin load failures visible at
+      # all -- several shapes previously emitted NOTHING anywhere, not even on
+      # stderr. The log line is the entire contract, and on the deployed hosts it
+      # is the only per-file signal for 8 of 9 plugin files, so it is pinned by a
+      # test rather than by hope. Named here because build-release runs only the
+      # files it names; a patch-carried test that no step names is inert.
+      - name: Plugin loader observability tests
+        run: |
+          cd opencode-src/packages/opencode
+          bun test test/plugin/loader-observability.test.ts
+
       - name: Build CLI
         run: |
           cd opencode-src/packages/opencode

--- a/patches/apply.sh
+++ b/patches/apply.sh
@@ -350,6 +350,48 @@
 #                                               RouteProvider + ToastProvider. MUST apply LAST (it diffs against
 #                                               the full stack; tui-mcp-dialog also edits sync.tsx).
 #
+#  26. registry-port-fence.patch (local)    - refuse to claim a pool slot this process does not own,
+#                                               and fence markDead on identity so a restarting serve
+#                                               cannot evict the live owner of its old port. Previously
+#                                               undocumented in this list -- added here while numbering
+#                                               the next patch, since an undocumented entry is how the
+#                                               list silently stops describing the build.
+#
+#  27. plugin-loader-observability.patch (local) - make plugin load failures OBSERVABLE (bead
+#                                               workstation-5yox step 3a). The loader could fail to load
+#                                               a plugin and emit NOTHING ANYWHERE: report.error routes
+#                                               every stage to publishPluginError, which only publishes a
+#                                               Session.Event.Error that no log sink observes, and
+#                                               report.missing is a bare no-op that does not even do that.
+#                                               MEASURED on a real serve against three broken plugins: the
+#                                               unpatched binary produced 0 log lines, 0 level=ERROR lines
+#                                               and 118 bytes of stdout while answering HTTP 200. On this
+#                                               host that silence covers 8 of the 9 deployed plugin files,
+#                                               including two mkOutOfStoreSymlinks into other repos'
+#                                               live checkouts that have no build-time cover at all.
+#                                               Adds (a) logPluginError(), a structured logError beside the
+#                                               existing publishPluginError, called from ALL FOUR
+#                                               report.error stages AND from report.missing; (b) an INFO
+#                                               "plugin loaded" line per successfully applied plugin --
+#                                               INFO because a production log carries zero DEBUG lines, so
+#                                               DEBUG would not be emitted at all. Deliberately reuses the
+#                                               EXACT message text ("failed to load plugin") and `path`
+#                                               field of the pre-existing load-failure logError, so a log
+#                                               consumer needs no change to gain the new shapes; `stage`
+#                                               is appended to distinguish them for a human. Note an
+#                                               import-time throw arrives as stage "load", not the "entry"
+#                                               one might predict -- which is why all stages are covered
+#                                               rather than the interesting-looking one.
+#                                               Tests: test/plugin/loader-observability.test.ts, run by the
+#                                               "Plugin loader observability tests" step in
+#                                               build-release.yml -- a patch-carried test that no workflow
+#                                               names is inert. Verified non-vacuous by mutation: with the
+#                                               source hunks reverted all 4 go red.
+#                                               Disjoint from every other patch (no other patch touches
+#                                               plugin/{index,loader,shared}.ts), so order-independent.
+#                                               SUNSET: drop if upstream merges the equivalent; an upstream
+#                                               PR carries the same three changes.
+#
 # DROPPED on the v1.17 line (see workstation docs/plans/2026-06-11-opencode-1.17-cutover-runbook.md):
 #   - integration-list-batch.patch: DROPPED on the v1.17.13 roll-forward (2026-07-06).
 #     UPSTREAMED — v1.17.13 Integration.list now does the bulk shape natively:
@@ -437,6 +479,7 @@ PATCHES=(
   opus5-adaptive-thinking
   tui-reconcile-bound
   registry-port-fence
+  plugin-loader-observability
 )
 
 for name in "${PATCHES[@]}"; do

--- a/patches/plugin-loader-observability.patch
+++ b/patches/plugin-loader-observability.patch
@@ -1,0 +1,324 @@
+diff --git a/packages/opencode/src/plugin/index.ts b/packages/opencode/src/plugin/index.ts
+index 1558c70..deaec37 100644
+--- a/packages/opencode/src/plugin/index.ts
++++ b/packages/opencode/src/plugin/index.ts
+@@ -136,6 +136,17 @@ const layer = Layer.effect(
+           bridge.fork(events.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() }))
+         }
+ 
++        // Structured, per-plugin failure line for every non-loading shape.
++        //
++        // Deliberately reuses the exact message text and `path` field of the
++        // load-failure logError further down, so that one log consumer covers
++        // every shape: a plugin that fails to import, one whose entrypoint is
++        // missing, and one whose factory rejects all read identically.
++        // `stage` distinguishes them for a human without changing the shape.
++        function logPluginError(spec: string, stage: string, message: string) {
++          bridge.fork(Effect.logError("failed to load plugin", { path: spec, stage, error: message }))
++        }
++
+         const { Server } = yield* Effect.promise(() => import("../server/server"))
+ 
+         const serverUrl = Server.url
+@@ -185,12 +196,29 @@ const layer = Layer.effect(
+             kind: "server",
+             report: {
+               start(candidate) {},
+-              missing(candidate, _retry, message) {},
++              missing(candidate, _retry, message) {
++                // A resolved target that exposes no entrypoint for this kind was
++                // previously reported NOWHERE: not a log line, not an event, not
++                // stderr. Same message string as the load-failure line below so a
++                // single log consumer covers every non-loading shape.
++                logPluginError(candidate.plan.spec, "missing", message)
++              },
+               error(candidate, _retry, stage, error, resolved) {
+                 const spec = candidate.plan.spec
+                 const cause = error instanceof Error ? (error.cause ?? error) : error
+                 const message = stage === "load" ? errorMessage(error) : errorMessage(cause)
+ 
++                // Every stage logs, in addition to publishing the event below.
++                // publishPluginError only emits a Session.Event.Error, which no
++                // log sink observes, so these failures produced NO output at all
++                // -- no log line, nothing on stderr -- while the server happily
++                // answered 200. Measured, on a real serve.
++                //
++                // All four stages are covered rather than the one that looks
++                // interesting: an import-time throw arrives as "load", not the
++                // "entry" one might reasonably predict.
++                logPluginError(spec, stage, message)
++
+                 if (stage === "install") {
+                   const parsed = parsePluginSpecifier(spec)
+                   publishPluginError(`Failed to install plugin ${parsed.pkg}@${parsed.version}: ${message}`)
+@@ -224,6 +252,7 @@ const layer = Layer.effect(
+               return message
+             },
+           }).pipe(
++            Effect.tap(() => Effect.logInfo("plugin loaded", { path: load.spec })),
+             Effect.tapError((error) => Effect.logError("failed to load plugin", { path: load.spec, error })),
+             Effect.catch(() => {
+               // TODO: make proper events for this
+diff --git a/packages/opencode/test/plugin/loader-observability.test.ts b/packages/opencode/test/plugin/loader-observability.test.ts
+new file mode 100644
+index 0000000..2ed07ef
+--- /dev/null
++++ b/packages/opencode/test/plugin/loader-observability.test.ts
+@@ -0,0 +1,257 @@
++import { describe, expect, afterEach } from "bun:test"
++import { LayerNode } from "@opencode-ai/core/effect/layer-node"
++import { Effect, Layer } from "effect"
++import * as TestConsole from "effect/testing/TestConsole"
++import path from "path"
++import { pathToFileURL } from "url"
++import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
++import { FSUtil } from "@opencode-ai/core/fs-util"
++import { Config } from "@/config/config"
++import { disposeAllInstances, provideInstance, testInstanceStoreLayer, tmpdirScoped } from "../fixture/fixture"
++import { testEffect } from "../lib/effect"
++
++const { Plugin } = await import("../../src/plugin/index")
++const { TestConfig } = await import("../fixture/config")
++const { RuntimeFlags } = await import("../../src/effect/runtime-flags")
++
++afterEach(async () => {
++  await disposeAllInstances()
++})
++
++const it = testEffect(
++  Layer.mergeAll(LayerNode.compile(LayerNode.group([CrossSpawnSpawner.node, FSUtil.node])), testInstanceStoreLayer),
++)
++
++type Record_ = { level: string; message: string; annotations: Record<string, unknown> }
++
++/**
++ * Reassembles the flat console output into log records.
++ *
++ * The logger emits three consecutive arguments per record -- a `[time] LEVEL
++ * (#fiber):` prefix, the message, and an annotations object -- so the level and
++ * the annotations are recovered by position.
++ */
++function records(lines: ReadonlyArray<unknown>): Record_[] {
++  const out: Record_[] = []
++  for (let i = 0; i < lines.length; i++) {
++    const head = lines[i]
++    if (typeof head !== "string") continue
++    const level = head.match(/\]\s+([A-Z]+)\s+\(#/)?.[1]
++    if (!level) continue
++    const message = lines[i + 1]
++    if (typeof message !== "string") continue
++    const next = lines[i + 2]
++    const annotations = typeof next === "object" && next !== null && !Array.isArray(next) ? (next as Record<string, unknown>) : {}
++    out.push({ level, message, annotations })
++  }
++  return out
++}
++
++/**
++ * Loads the plugins declared in `dir/opencode.json` and returns the log records
++ * emitted while doing so.
++ *
++ * The log line IS the contract these tests protect. For several failure shapes
++ * it is the only signal that reaches anywhere at all: upstream reported them
++ * through `publishPluginError`, which emits a `Session.Event.Error` that no log
++ * sink observes, so a plugin could fail while the server answered 200 and
++ * nothing recorded it. Asserting on emitted records rather than on internal
++ * state keeps these tests pointed at what is observable in production.
++ */
++function loadCapturingLogs(dir: string) {
++  const source = path.join(dir, "opencode.json")
++  return Effect.gen(function* () {
++    const config = yield* Effect.promise(
++      () => Bun.file(source).json() as Promise<{ plugin?: Array<string | [string, Record<string, unknown>]> }>,
++    )
++    const plugins = config.plugin ?? []
++
++    yield* Effect.gen(function* () {
++      const plugin = yield* Plugin.Service
++      yield* plugin.list()
++    }).pipe(
++      Effect.provide(
++        LayerNode.compile(Plugin.node, [
++          [
++            Config.node,
++            TestConfig.layer({
++              get: () =>
++                Effect.succeed({
++                  plugin: plugins,
++                  plugin_origins: plugins.map((plugin) => ({ spec: plugin, source, scope: "local" as const })),
++                }),
++              directories: () => Effect.succeed([dir]),
++            }),
++          ],
++          [RuntimeFlags.node, RuntimeFlags.layer({ disableDefaultPlugins: true })],
++        ]),
++      ),
++      provideInstance(dir),
++    )
++
++    // The failure lines are emitted from a forked root fiber -- the reporting
++    // callback is not in Effect context -- so they are not ordered with respect
++    // to the load completing. Poll rather than sleeping a fixed interval, which
++    // is both faster in the normal case and less flaky on a loaded runner.
++    let seen: Record_[] = []
++    for (let i = 0; i < 100; i++) {
++      seen = records(yield* TestConsole.logLines)
++      if (seen.some((r) => r.message === "failed to load plugin" || r.message === "plugin loaded")) break
++      yield* Effect.sleep("10 millis")
++    }
++    return seen
++  })
++}
++
++function withTmp<A, E, R>(init: (dir: string) => Promise<void>, body: (dir: string) => Effect.Effect<A, E, R>) {
++  return Effect.gen(function* () {
++    const dir = yield* tmpdirScoped()
++    yield* Effect.promise(() => init(dir))
++    return yield* body(dir)
++  })
++}
++
++const failures = (rs: Record_[]) => rs.filter((r) => r.message === "failed to load plugin")
++const successes = (rs: Record_[]) => rs.filter((r) => r.message === "plugin loaded")
++
++describe("plugin.loader.observability", () => {
++  it.live("logs a failure line for a plugin that throws while being imported", () =>
++    withTmp(
++      async (dir) => {
++        const file = path.join(dir, "boom.ts")
++        await Bun.write(file, 'throw new Error("deliberate import-time explosion")\n')
++        await Bun.write(path.join(dir, "opencode.json"), JSON.stringify({ plugin: [pathToFileURL(file).href] }))
++      },
++      (dir) =>
++        Effect.gen(function* () {
++          const failed = failures(yield* loadCapturingLogs(dir))
++
++          // EXACTLY one. loadExternal only retries when called with `wait`, and
++          // this call site does not pass it -- it awaits config dependencies
++          // beforehand instead -- so a failure is reported once. Asserting `>= 1`
++          // here would let a duplicate-emitter regression pass green.
++          expect(failed.length).toBe(1)
++          expect(failed[0]!.level).toBe("ERROR")
++          expect(String(failed[0]!.annotations["path"])).toContain("boom.ts")
++          // An import-time throw surfaces as "load", not the "entry" one might
++          // predict. Pinned, because that expectation is what justifies covering
++          // every stage rather than the interesting-looking one.
++          expect(failed[0]!.annotations["stage"]).toBe("load")
++          expect(String(failed[0]!.annotations["error"])).toContain("deliberate import-time explosion")
++
++          // The production log consumer extracts the plugin key from a
++          // `path=file://...` field and yields a shared "unknown" key without it,
++          // silently collapsing per-file signal. Config normalisation is what
++          // guarantees the shape, so it is asserted rather than assumed.
++          expect(String(failed[0]!.annotations["path"]).startsWith("file://")).toBe(true)
++        }),
++    ),
++  )
++
++  it.live("logs a failure line when the target exposes no server entrypoint", () =>
++    withTmp(
++      async (dir) => {
++        // A directory plugin whose package.json carries an `exports` record that
++        // resolves no server entrypoint reaches the "missing" stage. Upstream
++        // reports that stage through a callback that is a bare no-op -- it does
++        // not even publish an event -- so this shape was strictly quieter than a
++        // load error, and completely invisible.
++        const plugdir = path.join(dir, "noentry")
++        await Bun.write(
++          path.join(plugdir, "package.json"),
++          JSON.stringify({ name: "noentry", version: "0.0.1", type: "module", exports: { "./tui": "./tui.js" } }),
++        )
++        await Bun.write(path.join(dir, "opencode.json"), JSON.stringify({ plugin: [plugdir] }))
++      },
++      (dir) =>
++        Effect.gen(function* () {
++          const failed = failures(yield* loadCapturingLogs(dir))
++
++          expect(failed.length).toBe(1)
++          expect(failed[0]!.level).toBe("ERROR")
++          expect(failed[0]!.annotations["stage"]).toBe("missing")
++          expect(String(failed[0]!.annotations["path"])).toContain("noentry")
++        }),
++    ),
++  )
++
++  it.live("logs a success line naming each plugin that loaded", () =>
++    withTmp(
++      async (dir) => {
++        const file = path.join(dir, "fine.ts")
++        await Bun.write(file, 'export default { id: "fine", server: async () => ({}) }\n')
++        await Bun.write(path.join(dir, "opencode.json"), JSON.stringify({ plugin: [pathToFileURL(file).href] }))
++      },
++      (dir) =>
++        Effect.gen(function* () {
++          const rs = yield* loadCapturingLogs(dir)
++          const ok = successes(rs)
++
++          expect(ok.length).toBe(1)
++          expect(ok[0]!.level).toBe("INFO")
++          expect(String(ok[0]!.annotations["path"])).toContain("fine.ts")
++          expect(failures(rs).length).toBe(0)
++        }),
++    ),
++  )
++
++  it.live("logs a failure line when the plugin factory itself rejects", () =>
++    withTmp(
++      async (dir) => {
++        const file = path.join(dir, "rejects.ts")
++        await Bun.write(file, 'export default { id: "rejects", server: async () => { throw new Error("factory rejected") } }\n')
++        await Bun.write(path.join(dir, "opencode.json"), JSON.stringify({ plugin: [pathToFileURL(file).href] }))
++      },
++      (dir) =>
++        Effect.gen(function* () {
++          const rs = yield* loadCapturingLogs(dir)
++          const failed = failures(rs)
++
++          // This shape is reported by the loader's PRE-EXISTING logError, not by
++          // the one this patch adds -- so it carries no `stage`. It is pinned
++          // here anyway: it shares the message string that the production log
++          // consumer matches on, and nothing else in this suite would notice if
++          // an upstream rebase reworded it.
++          expect(failed.length).toBe(1)
++          expect(failed[0]!.level).toBe("ERROR")
++          expect(String(failed[0]!.annotations["path"])).toContain("rejects.ts")
++          expect(String(failed[0]!.annotations["error"])).toContain("factory rejected")
++
++          // A factory that rejects never applied, so it must not be reported as
++          // loaded. The success line is what a future consumer will treat as
++          // proof of health.
++          expect(successes(rs).length).toBe(0)
++        }),
++    ),
++  )
++
++  it.live("attributes the failure to the failing file and still loads its sibling", () =>
++    withTmp(
++      async (dir) => {
++        const bad = path.join(dir, "bad.ts")
++        const good = path.join(dir, "good.ts")
++        await Bun.write(bad, 'throw new Error("sibling explosion")\n')
++        await Bun.write(good, 'export default { id: "good", server: async () => ({}) }\n')
++        await Bun.write(
++          path.join(dir, "opencode.json"),
++          JSON.stringify({ plugin: [pathToFileURL(bad).href, pathToFileURL(good).href] }),
++        )
++      },
++      (dir) =>
++        Effect.gen(function* () {
++          const rs = yield* loadCapturingLogs(dir)
++
++          // Per-file attribution is what lets a consumer latch per plugin: a
++          // failure in one file must not be reported against another, and must
++          // not suppress the sibling's success line.
++          const ok = successes(rs)
++          expect(ok.length).toBe(1)
++          expect(String(ok[0]!.annotations["path"])).toContain("good.ts")
++
++          const failed = failures(rs)
++          expect(failed.length).toBe(1)
++          expect(String(failed[0]!.annotations["path"])).toContain("bad.ts")
++        }),
++    ),
++  )
++})


### PR DESCRIPTION
Step **3a** of the plugin-loader hardening roadmap (bead `workstation-5yox`). Observability only — the validation half is deliberately **not** here, see Scope below.

## The problem, measured

opencode's plugin loader can fail to load a plugin and emit **nothing anywhere**. `report.error` routes every stage to `publishPluginError`, which only publishes a `Session.Event.Error` that no log sink observes; `report.missing` is a bare no-op that does not even do that.

Measured on a real serve against three deliberately broken plugins:

| | unpatched (`1.17.13.7`) | patched |
|---|---|---|
| log lines mentioning a plugin | **0** | one per plugin |
| `level=ERROR` lines | **0** | one per failure |
| stdout/stderr | 118 bytes | — |
| HTTP status throughout | 200 | 200 |

Not a quiet failure — a silent one, with no evidence anywhere that a plugin had failed. On the deployed hosts that silence covers **8 of the 9** plugin files, two of which are `mkOutOfStoreSymlink`s into other repositories' live checkouts with no build-time cover at all.

## Changes

1. **`logPluginError()`** — a structured `logError` beside the existing `publishPluginError`, called from **all four** `report.error` stages **and** from `report.missing`.
2. **An INFO `"plugin loaded"` line** per successfully applied plugin.
3. **Tests, named by a `build-release.yml` step.** A patch-carried test no workflow names is inert.

### Two decisions worth stating

**The failure line reuses the exact existing message string and `path` field.** So the deployed log consumer gains every new failure shape with **zero changes**; `stage` is appended to distinguish them for a human. Verified: it matches both new lines and extracts the right key, and the INFO success line does not false-match its `level=ERROR` pattern.

**INFO, not DEBUG.** A production log here carries 84,020 INFO lines and **zero** DEBUG in a 20MB sample — at the default level DEBUG would not be emitted at all, making the signal useless. Volume is ~4,200 INFO lines/MB, so nine lines per directory init is a rounding error.

An import-time throw arrives as stage **`load`**, not the `entry` one might predict — which is exactly why all stages are covered rather than the interesting-looking one.

## Verification

- Built a real patched `linux-arm64` binary and ran a scratch serve; captured `stage=missing` and `stage=load` failures plus INFO success lines.
- Same controls against the **unpatched production binary** — the table above.
- Sourced the deployed log consumer and confirmed key extraction (`exportsonly`, `importthrow.ts`).
- **Mutation:** with the source hunks reverted, **4 of 5 tests go red**. The fifth stays green by design — it pins the loader's *pre-existing* factory-rejection line, which shares the matched message string and which nothing else would notice if a rebase reworded it.
- Full stack: all 27 patches apply to a clean `v1.17.13` clone; **33 tests pass** (the 5 new + the 28 existing `loader-shared`).

Each test asserts an **exact** line count, not a lower bound: `loadExternal` retries only when called with `wait`, which this call site does not pass, so a failure is reported exactly once and a duplicate-emitter regression must fail rather than pass. (My first draft used `>= 1`, justified by a retry path that review showed this call site cannot reach.)

## Scope

**Validation (`assertHooks` + buffer-then-commit) is deliberately excluded.** It converts a loud failure into a quiet one, and two of three deployed hosts have no detector — so shipping it with this would manufacture exactly the silent-failure class the roadmap exists to kill. It lands as 3b, gated on devbox cover. There is no validation logic in this diff.

The **pin machinery** is the companion workstation-side change, not this PR: the vendored loader fixtures become stale from the moment this deploys, and the guard needs to pin our patch's identity rather than the fork revision.

## Caveats

- `bridge.fork` runs the log on a root fiber, so a line can be lost if the process exits immediately after. Real only for short-lived one-shot runs, not serves.
- `"plugin loaded"` means *applied without throwing* — not that the plugin contributed working hooks. A future consumer treating it as proof of health must know that.

Order-independent: none of the other 26 patches touch `plugin/{index,loader,shared}.ts`.

Also documents `registry-port-fence` as #26, which was never written up — an undocumented entry is how that list silently stops describing the build.